### PR TITLE
Add initial Docker support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: ["main"]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:20-alpine AS base
+
+RUN npm install -g pnpm
+
+WORKDIR /app
+
+FROM base AS deps
+# Because of docker layer caching dependencies should only be re-installed if package.json or pnpm-lock.yaml change.
+
+COPY package.json pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+
+COPY --from=deps /app/node_modules ./node_modules
+
+COPY . .
+
+RUN pnpm build
+
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# non root user for security
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+
+COPY --chown=nextjs:nodejs package.json pnpm-lock.yaml ./
+
+# Install only prod dependencies
+RUN pnpm install --prod --frozen-lockfile
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["pnpm", "start"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ pnpm run dev
 pnpm run build
 ```
 
+### Running with Docker
+
+To run the application using Docker, first ensure you have Docker installed.
+The Docker image is published to GitHub Container Registry (ghcr.io).
+
+#### Docker run
+
+```bash
+# Pull the latest image from ghcr.io
+docker pull ghcr.io/airyland/datetime.app:latest
+
+# Run the Docker container
+docker run -d -p 3000:3000 --name datetime-app ghcr.io/airyland/datetime.app:latest
+```
+
+Then, open your browser and navigate to `http://localhost:3000`.
+
+#### Docker compose
+
+See the `docker-compose.yaml` file in the repository for a complete setup.
+
 ## Other Products
 
 Check out our other tools and services:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  datetime.app:
+    ports:
+      - 3000:3000
+    container_name: datetime-app
+    image: ghcr.io/airyland/datetime.app:latest


### PR DESCRIPTION
This pull request was to address #2 and add support for running the site with Docker.

Changes:
* Added a GitHub Actions workflow `.github/workflows/docker-publish.yml` to build and publish Docker images to GitHub Container Registry (`ghcr.io`)
* Created a multi-stage `Dockerfile` to optimize image size and build efficiency. It includes stages for dependency installation (`deps`), application building (`builder`), and production runtime (`runner`). The separate steps should make for an overall smaller image but this may be able to be further improved
* Updated `README.md` to include instructions for running the application with Docker
* Added a simple `docker-compose.yaml` file to get someone up and running quick
* Builds for `amd64` and `arm64` at the moment

I have tested the image built locally but my download speed from ghcr.io is quite slow at the moment so haven't finished testing the image built in the CI