### PR TITLE
fix: a bg-color bug of fullscreen in app/[locale]/page.tsx

### DIFF
--- a/components/fullscreen-time.tsx
+++ b/components/fullscreen-time.tsx
@@ -65,13 +65,13 @@ export function FullscreenTime({ time, isFullscreen, onClose }: FullscreenTimePr
 
   return (
     <div 
-      className="fixed inset-0 bg-black dark:bg-white flex items-center justify-center z-50"
+      className="fixed inset-0 bg-white dark:bg-black flex items-center justify-center z-50"
       ref={containerRef}
       onClick={onClose}
     >
       <div 
         ref={timeRef}
-        className={`text-white dark:text-black font-bold tracking-tight leading-none ${jetbrainsMono.className}`}
+        className={`text-black dark:text-white font-bold tracking-tight leading-none ${jetbrainsMono.className}`}
         style={{ fontSize: `${fontSize}px` }}
       >
         {time}


### PR DESCRIPTION
## ​​Title: Incorrect Color Scheme in Fullscreen Mode for "Current Time Tab"​​
### ​​Description:​​
There is a visual bug in the homepage's "Current Time Tab." When entering fullscreen mode, the color scheme contradicts the current theme setting.
- In ​​Dark Mode​​, the fullscreen panel displays a ​​white background with black text​​.
- In ​​Light Mode​​, it incorrectly shows a ​​black background with white text​​.

This is a reversal of the expected behavior, where Dark Mode should have a dark background with light text, and vice versa. I encountered this issue months ago, and the inverted colors are particularly harsh on the eyes at night.

### These two videos show the difference.​:
before:

https://github.com/user-attachments/assets/6a3a233c-ada0-4a2e-a833-06a9b1c2125d

after:

https://github.com/user-attachments/assets/3ce2677d-8d93-4e84-87bb-801d701bef9c



